### PR TITLE
Fix navigation error when dots are disabled

### DIFF
--- a/src/owl.carousel2.thumbs.js
+++ b/src/owl.carousel2.thumbs.js
@@ -135,7 +135,7 @@
                 // slide to slide :)
                 $('[data-slider-id=' + this._identifier + ']').trigger('to.owl.carousel', [index, options.dotsSpeed, true]);
             } else {
-                this.owl.to(index, options.dotsSpeed);
+                this.owl.to(index, options.dotsSpeed, true);
             }
 
             e.preventDefault();


### PR DESCRIPTION
This fixes an error when using with an older version of Owl (I can't upgrade due to an integration not working)
